### PR TITLE
test(e2e): update e2e tests, add --nobuild and --nolink options

### DIFF
--- a/tests/e2e/tests/010_user/010_login.ts
+++ b/tests/e2e/tests/010_user/010_login.ts
@@ -1,4 +1,4 @@
-import { executeSilent, npmLogin } from '../../utils/process';
+import { npmLogin } from '../../utils/process';
 import * as fs from '../../utils/fs';
 import { generateHash } from '../../../../src/api/auth';
 import { EOL } from 'os';
@@ -17,5 +17,5 @@ export default function() {
       return fs.replaceInFile(authPath, find, replace);
     })
     .then(() => npmLogin('admin', 'blabla', 'foo@bar.com'))
-    .then(() => executeSilent('npm logout'));
+    .then(code => code === 0 ? Promise.resolve() : Promise.reject(code));
 }

--- a/tests/e2e/tests/010_user/020_logout.ts
+++ b/tests/e2e/tests/010_user/020_logout.ts
@@ -1,7 +1,9 @@
-import { executeSilent, npmLogin } from '../../utils/process';
+import { exec, npmLogin } from '../../utils/process';
 
 export default function() {
   return Promise.resolve()
     .then(() => npmLogin('admin', 'blabla', 'foo@bar.com'))
-    .then(() => executeSilent('npm logout'));
+    .then(code => code === 0 ? Promise.resolve() : Promise.reject(code))
+    .then(() => exec('npm', ['logout']))
+    .then(resp => resp.code === 0 ? Promise.resolve() : Promise.reject(resp.stderr));
 }

--- a/tests/e2e/tests/010_user/030_false_login.ts
+++ b/tests/e2e/tests/010_user/030_false_login.ts
@@ -2,11 +2,6 @@ import { npmLogin } from '../../utils/process';
 
 export default function() {
   return Promise.resolve()
-    .then(() => {
-      return new Promise((resolve, reject) => {
-        npmLogin('admin', 'blablabla', 'foo@bar.com')
-          .then(() => reject())
-          .catch(err => resolve());
-      });
-    });
+    .then(() => npmLogin('admin', 'blablabla', 'foo@bar.com'))
+    .then(code => code !== 0 ? Promise.resolve() : Promise.reject(code));
 }

--- a/tests/e2e/utils/process.ts
+++ b/tests/e2e/utils/process.ts
@@ -140,12 +140,7 @@ function _exec(options: ExecOptions, cmd: string, args: string[]): Promise<Proce
     });
 
     childProcess.on('close', (code: number) => {
-      if (code === 0) {
-        resolve({ stdout, stderr, code });
-      } else {
-        const err = new Error(`Running "${cmd} ${args.join(' ')}" returned error code `);
-        reject(err);
-      }
+      resolve({ stdout, stderr, code });
     });
   });
 }
@@ -197,7 +192,6 @@ export function execute(options: ExecOptions, cmd: string): Promise<any> {
 }
 
 export function exec(cmd, args) {
-  console.log(cmd, args.join(' '));
   return _exec({ silent: false }, cmd, args);
 }
 
@@ -222,6 +216,6 @@ export function npmLogin(uname: string, passwd: string, email: string): Promise<
       .when(/Password/ig).respond(passwd + '\n')
       .when(/Email/ig).respond(email + '\n')
       .on('error', err => reject(err))
-      .end(code => code === 0 ? resolve(code) : reject());
+      .end(code => resolve(code));
   });
 }

--- a/tests/e2e_runner.ts
+++ b/tests/e2e_runner.ts
@@ -7,7 +7,7 @@ import { morose, killAllProcesses } from './e2e/utils/process';
 Error.stackTraceLimit = Infinity;
 
 const argv = minimist(process.argv.slice(2), {
-  boolean: ['debug', 'verbose'],
+  boolean: ['debug', 'verbose', 'nolink', 'nobuild'],
   string: ['glob', 'ignore']
 });
 
@@ -18,12 +18,23 @@ let currentFileName = null;
 let index = 0;
 
 const e2eRoot = path.join(__dirname, 'e2e');
-const allSetups = glob.sync(path.join(e2eRoot, 'setup/**/*.ts'), { nodir: true })
+let allSetups = glob.sync(path.join(e2eRoot, 'setup/**/*.ts'), { nodir: true })
   .map(name => path.relative(e2eRoot, name))
   .sort();
-const allTests = glob.sync(path.join(e2eRoot, testGlob), { nodir: true, ignore: argv.ignore })
+
+let allTests = glob.sync(path.join(e2eRoot, testGlob), { nodir: true, ignore: argv.ignore })
   .map(name => path.relative(e2eRoot, name))
   .sort();
+
+console.log(argv);
+
+if (argv['nolink']) {
+  allSetups = allSetups.filter(name => !name.includes('npm-link.ts'));
+}
+
+if (argv['nobuild']) {
+  allSetups = allSetups.filter(name => !name.includes('build.ts'));
+}
 
 const testsToRun = allSetups
   .concat(allTests


### PR DESCRIPTION
tests can now be run as:

```ts
node tests/run_e2e.js --nobuild
```
or
```ts
node tests/run_e2e.js --nolink
```
or with both options ofc.